### PR TITLE
Update SyncFile.php

### DIFF
--- a/src/Command/SyncFile.php
+++ b/src/Command/SyncFile.php
@@ -53,7 +53,7 @@ class SyncFile implements SelfHandling
 
         $content = $this->dispatch(new GetFile($this->fieldType));
 
-        if (md5($content) == md5($entry->getRawAttribute($this->fieldType->getField(), false))) {
+        if (md5($content) == md5(array_get($entry->getAttributes(), $this->fieldType->getField())) {
             return $content;
         }
 
@@ -65,7 +65,7 @@ class SyncFile implements SelfHandling
 
             $this->dispatch(new PutFile($this->fieldType));
 
-            $content = $entry->getRawAttribute($this->fieldType->getField(), false);
+            $content = array_get($entry->getAttributes(), $this->fieldType->getField());
         }
 
         $this->dispatch(new ClearCache());


### PR DESCRIPTION
Old syntax was returning null for all translatable fields.  Hence it would wind up recreating the database entry from file over and over again as the md5 line does not ever get a match.  This in turn fires saved observers on every load of of the field
